### PR TITLE
instanceof removed

### DIFF
--- a/src/main/java/gameframework/drawing/GameUniverseViewPortDefaultImpl.java
+++ b/src/main/java/gameframework/drawing/GameUniverseViewPortDefaultImpl.java
@@ -35,9 +35,7 @@ public class GameUniverseViewPortDefaultImpl implements GameUniverseViewPort {
 		Iterator<GameEntity> gt = getUniverse().getGameEntitiesIterator();
 		for (; gt.hasNext();) {
 			GameEntity tmp = gt.next();
-			if (tmp instanceof Drawable) {
-				((Drawable) tmp).draw(getBufferGraphics());
-			}
+			tmp.draw(getBufferGraphics());
 		}
 		refresh();
 	}

--- a/src/main/java/gameframework/game/GameEntity.java
+++ b/src/main/java/gameframework/game/GameEntity.java
@@ -1,4 +1,7 @@
 package gameframework.game;
 
+import java.awt.Graphics;
+
 public interface GameEntity {
+	public void draw(Graphics g);
 }


### PR DESCRIPTION
--Team 1--

We added the draw method to the GameEntity interface. This way, all GameEntity contains a draw method.
As it is not defined, except in Drawables, this method will only draw what is possible to draw, without the need of an instanceof.
