### PR TITLE
heritage test MoveStrategyKeyboard

### DIFF
--- a/src/test/java/gameframework/motion/MoveStrategyKeyboard8DirTest.java
+++ b/src/test/java/gameframework/motion/MoveStrategyKeyboard8DirTest.java
@@ -13,8 +13,18 @@ public class MoveStrategyKeyboard8DirTest extends
 	}
 	
 	@Override
+	protected MoveStrategyKeyboard8Dir createStrategyKeyboard() {
+		return new MoveStrategyKeyboard8Dir();
+	}
+
+	@Override
 	protected MoveStrategyKeyboard8Dir createStrategyKeyboard(Boolean alwaysMove) {
 		return new MoveStrategyKeyboard8Dir(alwaysMove);
+	}
+
+	@Override
+	protected MoveStrategyKeyboard8Dir createStrategyKeyboard(Boolean alwaysMove, SpeedVector speedVector) {
+		return new MoveStrategyKeyboard8Dir(alwaysMove, speedVector);
 	}
 
 	@Test

--- a/src/test/java/gameframework/motion/MoveStrategyKeyboardTest.java
+++ b/src/test/java/gameframework/motion/MoveStrategyKeyboardTest.java
@@ -17,10 +17,24 @@ public class MoveStrategyKeyboardTest extends
 	}
 
 	/**
+	 * Use the constructor without parameters.
+	 */
+	protected MoveStrategyKeyboard createStrategyKeyboard() {
+		return new MoveStrategyKeyboard();
+	}
+
+	/**
 	 * Use the constructor with 1 parameter (Boolean).
 	 */
 	protected MoveStrategyKeyboard createStrategyKeyboard(Boolean alwaysMove) {
 		return new MoveStrategyKeyboard(alwaysMove);
+	}
+
+	/**
+	 * Use the constructor with 2 parameters (Boolean, SpeedVector).
+	 */
+	protected MoveStrategyKeyboard createStrategyKeyboard(Boolean alwaysMove, SpeedVector speedVector) {
+		return new MoveStrategyKeyboard(alwaysMove, speedVector);
 	}
 
 	@Test
@@ -49,7 +63,7 @@ public class MoveStrategyKeyboardTest extends
 
 	@Test
 	public void stopWhenAlwaysMoveisOff() throws Exception {
-		strategy = new MoveStrategyKeyboard(false);
+		strategy = createStrategyKeyboard(false);
 		strategy.keyPressed(KeyEvent.VK_DOWN);
 		strategy.keyReleased(KeyEvent.VK_DOWN);
 		assertNoMovement();
@@ -65,7 +79,7 @@ public class MoveStrategyKeyboardTest extends
 
 	@Test
 	public void defaultValues() throws Exception {
-		strategy = new MoveStrategyKeyboard();
+		strategy = createStrategyKeyboard();
 		assertTrue(strategy.alwaysMove);
 		assertNoMovement();
 	}
@@ -81,7 +95,7 @@ public class MoveStrategyKeyboardTest extends
 	@Test
 	public void initializedValues() throws Exception {
 		SpeedVector speedVector = new SpeedVector(new Point(5,5), 50);
-		strategy = new MoveStrategyKeyboard(false, speedVector);
+		strategy = createStrategyKeyboard(false, speedVector);
 
 		assertEquals(speedVector, strategy.speedVector);
 		assertEquals(false, strategy.alwaysMove);


### PR DESCRIPTION
--Team 5--

We noticed that the "keyReleased" method in "MoveStrategyKeyboardDir" was not tested. The problem comes from several tests in 'MoveStrategyKeyboardTest' which directly call builders of "MoveStrategyKeyboard". By creating the heritage of tests, we had to do builders of "MoveStrategyKeyboard8Dir" again. Also, these changes have highlighted an error in the "keyReleased" method in "MoveStrategyKeyboard8Dir".