### PR TITLE
add test in MoveStrategyKeyboardTest and fix bug

### DIFF
--- a/src/main/java/gameframework/motion/MoveStrategyKeyboard8Dir.java
+++ b/src/main/java/gameframework/motion/MoveStrategyKeyboard8Dir.java
@@ -45,16 +45,16 @@ public class MoveStrategyKeyboard8Dir extends MoveStrategyKeyboard {
 		int y = speedVector.getDirection().y;
 		switch (keyCode) {
 		case KeyEvent.VK_RIGHT:
-			x++;
+			x = 1;
 			break;
 		case KeyEvent.VK_LEFT:
-			x--;
+			x = -1;
 			break;
 		case KeyEvent.VK_UP:
-			y--;
+			y = -1;
 			break;
 		case KeyEvent.VK_DOWN:
-			y++;
+			y = 1;
 			break;
 		default:
 			return;
@@ -86,16 +86,12 @@ public class MoveStrategyKeyboard8Dir extends MoveStrategyKeyboard {
 			int y = speedVector.getDirection().y;
 			switch (keyCode) {
 			case KeyEvent.VK_RIGHT:
-				x--;
-				break;
 			case KeyEvent.VK_LEFT:
-				x++;
+				x = 0;
 				break;
 			case KeyEvent.VK_UP:
-				y++;
-				break;
 			case KeyEvent.VK_DOWN:
-				y--;
+				y = 0;
 				break;
 			default:
 				return;

--- a/src/test/java/gameframework/motion/MoveStrategyKeyboardTest.java
+++ b/src/test/java/gameframework/motion/MoveStrategyKeyboardTest.java
@@ -101,4 +101,16 @@ public class MoveStrategyKeyboardTest extends
 		assertEquals(false, strategy.alwaysMove);
 	}
 
+	@Test
+	public void shouldMoveRightWhenAlwaysMoveisOn() {
+		strategy = createStrategyKeyboard(true);
+		strategy.keyPressed(KeyEvent.VK_LEFT);
+		strategy.keyReleased(KeyEvent.VK_LEFT);
+		strategy.keyPressed(KeyEvent.VK_LEFT);
+		strategy.keyReleased(KeyEvent.VK_LEFT);
+		strategy.keyPressed(KeyEvent.VK_RIGHT);
+		strategy.keyReleased(KeyEvent.VK_RIGHT);
+		assertRight();
+	}
+
 }


### PR DESCRIPTION
--Team 5--

I found that if you press (then release) the left key two times and the right key one time (for example), we will continue to go left with the class "MoveStrategyKeyboard8Dir" (when always move is on). But we must go right.
So I created a test to check my idea and I corrected the problem.