### PR TITLE
Refactoring computeOneOverlap Method

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -32,5 +32,6 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.junit.JUNIT_CONTAINER/4"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/src/main/java/gameframework/motion/overlapping/OverlapProcessorDefaultImpl.java
+++ b/src/main/java/gameframework/motion/overlapping/OverlapProcessorDefaultImpl.java
@@ -68,33 +68,24 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 
 	protected void computeOneOverlap(Overlappable movableOverlappable,
 			Vector<Overlap> overlaps) {
-		Area overlappableArea, targetArea;
-		Rectangle boundingBoxTarget, boundingBoxOverlappable;
+		Area overlappableArea;
+		Rectangle boundingBoxOverlappable;
 		assert movableOverlappable instanceof Movable;
 		Shape intersectShape = intersectionComputation(movableOverlappable);
 
 		overlappableArea = new Area(intersectShape);
 		boundingBoxOverlappable = intersectShape.getBounds();
 
-		for (Overlappable targetNonMovableOverlappable : nonMovableOverlappables) {
-			if (targetNonMovableOverlappable != movableOverlappable) {
-				// NOTE I don't see how this test could fail
-				Shape targetShape;
-				targetShape = targetNonMovableOverlappable.getBoundingBox();
-				boundingBoxTarget = targetShape.getBounds();
-
-				if (boundingBoxOverlappable.intersects(boundingBoxTarget)) {
-					targetArea = new Area(targetShape);
-					targetArea.intersect(overlappableArea);
-					if (!targetArea.isEmpty()) {
-						// NOTE I don't see how this test could fail
-						overlaps.add(new Overlap(movableOverlappable,
-								targetNonMovableOverlappable));
-					}
-				}
-			}
-		}
-
+		computeOneOverlapMovables(movableOverlappable, overlaps, boundingBoxOverlappable, overlappableArea);
+		computeOneOverlapNonMovableOverlappables(movableOverlappable, overlaps, boundingBoxOverlappable, overlappableArea);
+		
+	}
+	
+	protected void computeOneOverlapMovables(Overlappable movableOverlappable,
+			Vector<Overlap> overlaps, Rectangle boundingBoxOverlappable,
+			Area overlappableArea){
+		Rectangle boundingBoxTarget;
+		Area targetArea;
 		for (Overlappable targetOverlappable : movablesTmp) {
 			if (targetOverlappable != movableOverlappable) {
 				Shape targetShape;
@@ -117,6 +108,33 @@ public class OverlapProcessorDefaultImpl implements OverlapProcessor {
 				}
 			}
 		}
+	}
+	
+	protected void computeOneOverlapNonMovableOverlappables(Overlappable movableOverlappable,
+			Vector<Overlap> overlaps, Rectangle boundingBoxOverlappable,
+			Area overlappableArea){
+		
+		Rectangle boundingBoxTarget;
+		Area targetArea;
+		for (Overlappable targetNonMovableOverlappable : nonMovableOverlappables) {
+			if (targetNonMovableOverlappable != movableOverlappable) {
+				// NOTE I don't see how this test could fail
+				Shape targetShape;
+				targetShape = targetNonMovableOverlappable.getBoundingBox();
+				boundingBoxTarget = targetShape.getBounds();
+
+				if (boundingBoxOverlappable.intersects(boundingBoxTarget)) {
+					targetArea = new Area(targetShape);
+					targetArea.intersect(overlappableArea);
+					if (!targetArea.isEmpty()) {
+						// NOTE I don't see how this test could fail
+						overlaps.add(new Overlap(movableOverlappable,
+								targetNonMovableOverlappable));
+					}
+				}
+			}
+		}
+		
 	}
 
 	protected Shape intersectionComputation(Overlappable movableOverlappable) {


### PR DESCRIPTION
Refactoring the computeOneOverlap Method who compute the overlap between an Overlappable and movable overlappables and non movable overlappables. 

The old version was huge and compute for two type of overlappable.
Now the compute is separate in two call, one for movables overlappables and one for non movable overlappables.