### PR TITLE
Ignoring moveblocker collision with itself

### DIFF
--- a/src/main/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImpl.java
+++ b/src/main/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImpl.java
@@ -43,7 +43,7 @@ public class MoveBlockerCheckerDefaultImpl implements MoveBlockerChecker {
 
 		for (MoveBlocker moveBlocker : moveBlockers) {
 			Rectangle tmpB = moveBlocker.getBoundingBox();
-			if (tmpIntersec.intersects(tmpB)) {
+			if (m != moveBlocker && tmpIntersec.intersects(tmpB)) {
 				Area tmpArea = new Area(tmpB);
 				tmpArea.intersect(intersectArea);
 				if (!tmpArea.isEmpty()) {

--- a/src/test/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImplTest.java
+++ b/src/test/java/gameframework/motion/blocking/MoveBlockerCheckerDefaultImplTest.java
@@ -79,6 +79,10 @@ public class MoveBlockerCheckerDefaultImplTest {
 			}
 		};
 	}
+	
+	protected MoveBlockerMovable createMoveBlockerMovable() {
+		return new MoveBlockerMovable();
+	}
 
 	public void assertMoveValidated() {
 		assertTrue(checker.moveValidation(movable, speedVector));
@@ -124,5 +128,27 @@ public class MoveBlockerCheckerDefaultImplTest {
 		checker.removeMoveBlocker(blocker);
 		assertMoveValidated();
 	}
+	
+	@Test
+	public void assertPlayerIsNotBlockingItself(){
+		setSpeedVector(1, 1, 1);
+		MoveBlockerMovable m = createMoveBlockerMovable();
+		checker.addMoveBlocker(m);
+		assertTrue(checker.moveValidation(m, speedVector));
+	}
 
+	class MoveBlockerMovable extends GameMovable implements MoveBlocker{
+	
+		@Override
+		public Rectangle getBoundingBox() {
+			return new Rectangle(0, 0, 10, 10);
+		}
+	
+		@Override
+		public void oneStepMoveAddedBehavior() {
+			//Nothing 
+		}
+		
+	}
+	
 }


### PR DESCRIPTION
If you want to create an GameMovable that is also a MoveBlocker, (for example if you want to check collision with projectiles), the entity will consider it is colliding with itself and will not be able to move.

We juste added a condition in MoveBlockerCheckerDefaultImpl that ignores collision with the MoveBlocker if it is the same object than the GameMovable currently tested.