### PR TITLE
[Refactoring] OverlapRulesApplierDefaultImpl

### DIFF
--- a/src/test/java/gameframework/motion/overlapping/OverlapRulesApplierDefaultImplTest.java
+++ b/src/test/java/gameframework/motion/overlapping/OverlapRulesApplierDefaultImplTest.java
@@ -8,58 +8,67 @@ import java.util.Vector;
 import org.junit.Before;
 import org.junit.Test;
 
+import gameframework.motion.overlapping.mocks.OverlappableMock;
+import gameframework.motion.overlapping.mocks.OverlappableMovableMock;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class OverlapRulesApplierDefaultImplTest {
 
-	int rulesApplied = 0;
-	OverlapRulesApplierDefaultImpl ruleApplier;
-	boolean ruleShouldCrash = false;
-	String error_message = "Something bad happened";
+	protected int rulesApplied = 0;
+	protected OverlapRulesApplierDefaultImpl ruleApplier;
+	protected boolean ruleShouldCrash = false;
+	protected String error_message = "Something bad happened";
+
+	protected OverlappableMock overlappable;
+	protected OverlappableMovableMock overlappableMovable;
 
 	@Before
 	public void createRuleApplier() {
-		ruleApplier = new OverlapRulesApplierDefaultImpl() {
+		overlappable 		= new OverlappableMock();
+		overlappableMovable = new OverlappableMovableMock();
+		ruleApplier 		= new OverlapRulesApplierDefaultImpl() {
 
 			@SuppressWarnings("unused")
 			// this method is only called using reflection, tools can't see that
-			public void overlapRule(Overlappable1 overlappable1,
-					Overlappable2 overlappable2) {
+			public void overlapRule(
+					OverlappableMock overlappable,
+					OverlappableMovableMock overlappableMovable )
+			{
 				rulesApplied++;
 				if (ruleShouldCrash) {
 					throw new RuntimeException(error_message);
 				}
 			}
-
 		};
 	}
 
 	@Test
 	public void testApplyRuleInCorrectOrder() {
-		ruleApplier.applyOverlapRules(new Vector<Overlap>(Arrays
-				.asList(new Overlap(//
-						new Overlappable1(),//
-						new Overlappable2()))));
+		ruleApplier.applyOverlapRules(
+			new Vector<Overlap>(Arrays.asList(
+					new Overlap(overlappable, overlappableMovable)
+				)));
 		assertEquals(1, rulesApplied);
 	}
 
 	@Test
 	public void testApplyRuleInReverseOrder() {
-		ruleApplier.applyOverlapRules(new Vector<Overlap>(Arrays
-				.asList(new Overlap(//
-						new Overlappable2(), //
-						new Overlappable1()))));
+		ruleApplier.applyOverlapRules(
+			new Vector<Overlap>(Arrays.asList(
+					new Overlap(overlappableMovable, overlappable)
+				)));
 		assertEquals(1, rulesApplied);
 	}
 
 	@Test
 	public void testApplyNonExistingRule() {
-		ruleApplier.applyOverlapRules(new Vector<Overlap>(Arrays
-				.asList(new Overlap(//
-						new Overlappable1(), //
-						new Overlappable1()))));
+		ruleApplier.applyOverlapRules(
+			new Vector<Overlap>(Arrays.asList(
+					new Overlap(overlappable, overlappable)
+				)));
 		assertEquals(0, rulesApplied);
 	}
 
@@ -67,10 +76,10 @@ public class OverlapRulesApplierDefaultImplTest {
 	public void testApplyCrashingRule() {
 		ruleShouldCrash = true;
 		try {
-			ruleApplier.applyOverlapRules(new Vector<Overlap>(Arrays
-					.asList(new Overlap(//
-							new Overlappable1(), //
-							new Overlappable2()))));
+			ruleApplier.applyOverlapRules(
+				new Vector<Overlap>(Arrays.asList(
+						new Overlap(overlappable, overlappableMovable)
+					)));
 			fail("Previous instruction should have crashed");
 		} catch (RuntimeException e) {
 			assertEquals(1, rulesApplied);
@@ -79,40 +88,4 @@ public class OverlapRulesApplierDefaultImplTest {
 		}
 	}
 
-}
-
-class Overlappable1 implements Overlappable {
-
-	@Override
-	public Rectangle getBoundingBox() {
-		return null;
-	}
-
-	@Override
-	public Point getPosition() {
-		return null;
-	}
-
-	@Override
-	public boolean isMovable() {
-		return false;
-	}
-}
-
-class Overlappable2 implements Overlappable {
-
-	@Override
-	public Rectangle getBoundingBox() {
-		return null;
-	}
-
-	@Override
-	public Point getPosition() {
-		return null;
-	}
-
-	@Override
-	public boolean isMovable() {
-		return false;
-	}
 }

--- a/src/test/java/gameframework/motion/overlapping/mocks/OverlappableMock.java
+++ b/src/test/java/gameframework/motion/overlapping/mocks/OverlappableMock.java
@@ -1,0 +1,24 @@
+package gameframework.motion.overlapping.mocks;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+
+import gameframework.motion.overlapping.Overlappable;
+
+public class OverlappableMock implements Overlappable {
+
+	@Override
+	public Rectangle getBoundingBox() {
+		return new Rectangle();
+	}
+
+	@Override
+	public boolean isMovable() {
+		return false;
+	}
+
+	@Override
+	public Point getPosition() {
+		return new Point(0, 0);
+	}
+}

--- a/src/test/java/gameframework/motion/overlapping/mocks/OverlappableMovableMock.java
+++ b/src/test/java/gameframework/motion/overlapping/mocks/OverlappableMovableMock.java
@@ -1,0 +1,25 @@
+package gameframework.motion.overlapping.mocks;
+
+import java.awt.Point;
+import java.awt.Rectangle;
+
+import gameframework.motion.overlapping.Overlappable;
+
+public class OverlappableMovableMock implements Overlappable {
+
+	@Override
+	public Rectangle getBoundingBox() {
+		return new Rectangle();
+	}
+
+	@Override
+	public boolean isMovable() {
+		return true;
+	}
+
+	@Override
+	public Point getPosition() {
+		return new Point(0, 0);
+	}
+
+}


### PR DESCRIPTION
* I deleted the code duplication *(with the classes `Overlappable1` and `Overlappable2`)* by adding two new mocks. The first mock one can move and the other not.

* I changed the visibility of attributes *(private -> protected)*.

* I rearranged the code to facilitate its reading *(cosmetic changes)*.

------
**Warning** : 
This PR is in conflict with the PR #103, because `Overlappable1` is remplaced by `mocks.OverlappableMock`.

------
**Opendev - Team 1**