### PR TITLE
Better MoveStrategyKeyboard

### DIFF
--- a/src/main/java/gameframework/motion/MoveStrategyConfigurableKeyboard.java
+++ b/src/main/java/gameframework/motion/MoveStrategyConfigurableKeyboard.java
@@ -1,0 +1,140 @@
+package gameframework.motion;
+
+import java.awt.Point;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * {@link MoveStrategy} which listens to the keyboard and answers new
+ * {@link SpeedVector speed vectors} based on what the user typed.
+ */
+public class MoveStrategyConfigurableKeyboard extends KeyAdapter implements MoveStrategy {
+	/* Used to store the direction and speed currently applied */
+	protected SpeedVector speedVector;
+	
+	/* Used to know if we should still move even when all the keys are up */
+	protected final Boolean alwaysMove;
+	
+	/* Used to associate a key with a direction */
+	protected Map<Integer, Point> directions;
+	
+	/* Used to remember every pressed key */
+	protected Set<Integer> keyPressed;
+	
+	/* Used to know if we combine the directions when multiple keys are pressed */
+	protected boolean combineDirections;
+
+	public MoveStrategyConfigurableKeyboard() {
+		this(true);
+	}
+
+	/**
+	 * @param alwaysMove is a boolean value that decides if a player moves continually or not. (so even if the keys are released,
+	 *  the object will still move in the last direction he was) (True by default)
+	 */
+	public MoveStrategyConfigurableKeyboard(Boolean alwaysMove) {
+		this(alwaysMove, new SpeedVector(new Point(0, 0)));
+	}
+
+	/**
+	 * @param speedVector is a given custom speedVector for the strategy.
+	 */
+	public MoveStrategyConfigurableKeyboard(SpeedVector speedVector) {
+		this(true, speedVector);
+	}
+	
+	/**
+	 * @param alwaysMove is a boolean value that decides if a player moves continually or not. (so even if the keys are released,
+	 *  the object will still move in the last direction he was) (True by default)
+	 * @param speedVector is a given custom speedVector for the strategy.
+	 */
+	public MoveStrategyConfigurableKeyboard(Boolean alwaysMove, SpeedVector speedVector) {
+		this(alwaysMove, speedVector, false);
+	}
+
+	/**
+	 * @param alwaysMove is a boolean value that decides if a player moves continually or not. (so even if the keys are released,
+	 *  the object will still move in the last direction he was) (True by default)
+	 * @param speedVector is a given custom speedVector for the strategy.
+	 * @param combineDirections is a boolean value that decides if directions are combined (so if this is true and the player press 
+	 *  the key for direction (0, -1) and the key for (1, 0) then this will result in moving in the direction (1, -1))
+	 */
+	public MoveStrategyConfigurableKeyboard(Boolean alwaysMove, SpeedVector speedVector, Boolean combineDirections) {
+		this.alwaysMove = alwaysMove;
+		this.speedVector = speedVector;
+		this.directions = new HashMap<Integer, Point>();
+		this.keyPressed = new HashSet<Integer>();
+		this.combineDirections = combineDirections;
+	}
+	
+	/**
+	 * Adds a direction controlled by a key
+	 * @param key The key associated with the direction
+	 * @param direction The direction used when the key is pressed
+	 */
+	public void addKeyDirection(int key, Point direction) {
+		directions.put(key, direction);
+	}
+
+	@Override
+	public SpeedVector getSpeedVector() {
+		return speedVector;
+	}
+
+	@Override
+	public void keyPressed(KeyEvent event) {
+		keyPressed(event.getKeyCode());
+	}
+	
+	@Override
+	public void keyReleased(KeyEvent event) {
+		keyReleased(event.getKeyCode());
+	}
+	
+	protected void keyPressed(int keyCode) {
+		keyPressed.add(keyCode);
+		updateDirection();
+	}
+	
+	protected void keyReleased(int keyCode) {
+		keyPressed.remove(keyCode);
+		updateDirection();
+	}
+	
+	/**
+	 * Update the direction depending on the keys pressed
+	 */
+	protected void updateDirection() {
+		final Point newDirection = new Point(0, 0);
+		
+		for (Integer keyCode : keyPressed) {
+			final Point keyDirection = directions.get(keyCode);
+			if (keyDirection != null) {
+				newDirection.x += keyDirection.x;
+				newDirection.y += keyDirection.y;
+				
+				// If we don't combine directions, then we should stop here
+				if (!combineDirections) {
+					break;
+				}
+			}
+		}
+		
+		if (newDirection.x != 0 || newDirection.y != 0 || !alwaysMove)
+			speedVector.setDirection(newDirection);
+	}
+
+	@Override
+	public int getSpeed() {
+		return this.speedVector.getSpeed();
+	}
+
+	@Override
+	public void setSpeed(int speed) {
+		this.speedVector.setSpeed(speed);
+	}
+}

--- a/src/main/java/gameframework/motion/MoveStrategyKeyboard.java
+++ b/src/main/java/gameframework/motion/MoveStrategyKeyboard.java
@@ -1,105 +1,47 @@
 package gameframework.motion;
 
 import java.awt.Point;
-import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 
 /**
  * {@link MoveStrategy} which listens to the keyboard and answers new
  * {@link SpeedVector speed vectors} based on what the user typed.
  */
-public class MoveStrategyKeyboard extends KeyAdapter implements MoveStrategy {
-	protected SpeedVector speedVector;
-	protected final Boolean alwaysMove;
-
+public class MoveStrategyKeyboard extends MoveStrategyConfigurableKeyboard {
 	public MoveStrategyKeyboard() {
 		this(true);
 	}
-
+	
+	/**
+	 * {@link MoveStrategyConfigurableKeyboard#MoveStrategyKeyboard(Boolean)}
+	 */
 	public MoveStrategyKeyboard(Boolean alwaysMove) {
 		this(alwaysMove, new SpeedVector(new Point(0, 0)));
 	}
-
+	
+	/**
+	 * {@link MoveStrategyConfigurableKeyboard#MoveStrategyKeyboard(SpeedVector)}
+	 */
 	public MoveStrategyKeyboard(SpeedVector speedVector) {
 		this(true, speedVector);
 	}
-
+	
 	/**
-	 * @param alwaysMove is a boolean value that decide if a player moves continually or not. (True by default)
-	 * @param speedVector is a given custom speedVector for the strategy.
+	 * {@link MoveStrategyConfigurableKeyboard#MoveStrategyKeyboard(Boolean, SpeedVector)}
 	 */
 	public MoveStrategyKeyboard(Boolean alwaysMove, SpeedVector speedVector) {
-		this.alwaysMove = alwaysMove;
-		this.speedVector = speedVector;
+		this(alwaysMove, speedVector, false);
 	}
-
-	@Override
-	public SpeedVector getSpeedVector() {
-		return speedVector;
-	}
-
-	@Override
-	public void keyPressed(KeyEvent event) {
-		keyPressed(event.getKeyCode());
-	}
-
-	public void keyPressed(int keyCode) {
-		switch (keyCode) {
-		case KeyEvent.VK_RIGHT:
-			goRight();
-			break;
-		case KeyEvent.VK_LEFT:
-			goLeft();
-			break;
-		case KeyEvent.VK_UP:
-			goUp();
-			break;
-		case KeyEvent.VK_DOWN:
-			goDown();
-			break;
-		default:
-			stay();
-		}
-	}
-
-	@Override
-	public void keyReleased(KeyEvent event) {
-		keyReleased(event.getKeyCode());
-	}
-
-	public void keyReleased(int keyCode) {
-		if (!alwaysMove) {
-			stay();
-		}
-	}
-
-	public void goRight() {
-		speedVector.setDirection(new Point(1, 0));
-	}
-
-	public void goLeft() {
-		speedVector.setDirection(new Point(-1, 0));
-	}
-
-	public void goUp() {
-		speedVector.setDirection(new Point(0, -1));
-	}
-
-	public void goDown() {
-		speedVector.setDirection(new Point(0, 1));
-	}
-
-	public void stay() {
-		speedVector.setDirection(new Point(0, 0));
-	}
-
-	@Override
-	public int getSpeed() {
-		return this.speedVector.getSpeed();
-	}
-
-	@Override
-	public void setSpeed(int speed) {
-		this.speedVector.setSpeed(speed);
+	
+	/**
+	 * {@link MoveStrategyConfigurableKeyboard#MoveStrategyKeyboard(Boolean, SpeedVector, Boolean)}
+	 */
+	public MoveStrategyKeyboard(Boolean alwaysMove, SpeedVector speedVector, Boolean combineDirections) {
+		super(alwaysMove, speedVector, combineDirections);
+		
+		addKeyDirection(KeyEvent.VK_RIGHT, new Point(1, 0));
+		addKeyDirection(KeyEvent.VK_LEFT, new Point(-1, 0));
+		addKeyDirection(KeyEvent.VK_DOWN, new Point(0, 1));
+		addKeyDirection(KeyEvent.VK_UP, new Point(0, -1));
 	}
 }

--- a/src/main/java/gameframework/motion/MoveStrategyKeyboard8Dir.java
+++ b/src/main/java/gameframework/motion/MoveStrategyKeyboard8Dir.java
@@ -1,7 +1,6 @@
 package gameframework.motion;
 
 import java.awt.Point;
-import java.awt.event.KeyEvent;
 
 /**
  * {@link MoveStrategy} which listens to the keyboard and answers new
@@ -12,16 +11,16 @@ import java.awt.event.KeyEvent;
  * @author Arnaud Cojez
  */
 public class MoveStrategyKeyboard8Dir extends MoveStrategyKeyboard {
-
-	// Methods
-
 	/**
 	 * Constructor for the MoveStrategyKeyboard8Dir class
 	 */
 	public MoveStrategyKeyboard8Dir() {
-		super(true);
+		this(true);
 	}
-
+	
+	/**
+	 * {@link MoveStrategyKeyboard#MoveStrategyKeyboard(Boolean)}
+	 */
 	public MoveStrategyKeyboard8Dir(Boolean alwaysMove) {
 		this(alwaysMove, new SpeedVector(new Point(0, 0)));
 	}
@@ -30,73 +29,6 @@ public class MoveStrategyKeyboard8Dir extends MoveStrategyKeyboard {
 	 * {@link MoveStrategyKeyboard#MoveStrategyKeyboard(Boolean, SpeedVector)}
 	 */
 	public MoveStrategyKeyboard8Dir(Boolean alwaysMove, SpeedVector speedVector) {
-		super(alwaysMove, speedVector);
+		super(alwaysMove, speedVector, true);
 	}
-
-	@Override
-	public void goRight() {
-		int y = speedVector.getDirection().y;
-		speedVector.setDirection(new Point(1, y));
-	}
-
-	@Override
-	public void goLeft() {
-		int y = speedVector.getDirection().y;
-		speedVector.setDirection(new Point(-1, y));
-	}
-
-	@Override
-	public void goUp() {
-		int x = speedVector.getDirection().x;
-		speedVector.setDirection(new Point(x, -1));
-	}
-
-	@Override
-	public void goDown() {
-		int x = speedVector.getDirection().x;
-		speedVector.setDirection(new Point(x, 1));
-	}
-
-	@Override
-	public void stay() {
-		return;
-	}
-
-	/**
-	 * Move according to the point parameter
-	 * 
-	 * @param point
-	 *            the new direction of the movement
-	 */
-	private void move(Point point) {
-		speedVector.setDirection(point);
-	}
-
-	/**
-	 * Processes the direction according to the key released
-	 * 
-	 * @param keyCode
-	 *            the code of the key released
-	 */
-	@Override
-	public void keyReleased(int keyCode) {
-		if (!alwaysMove) {
-			int x = speedVector.getDirection().x;
-			int y = speedVector.getDirection().y;
-			switch (keyCode) {
-			case KeyEvent.VK_RIGHT:
-			case KeyEvent.VK_LEFT:
-				x = 0;
-				break;
-			case KeyEvent.VK_UP:
-			case KeyEvent.VK_DOWN:
-				y = 0;
-				break;
-			default:
-				return;
-			}
-			move(new Point(x, y));
-		}
-	}
-
 }

--- a/src/test/java/gameframework/motion/MoveStrategyConfigurableKeyboardTest.java
+++ b/src/test/java/gameframework/motion/MoveStrategyConfigurableKeyboardTest.java
@@ -1,0 +1,129 @@
+package gameframework.motion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.awt.Point;
+import java.awt.event.KeyEvent;
+
+import org.junit.Test;
+
+public class MoveStrategyConfigurableKeyboardTest extends
+		MoveStrategyTest<MoveStrategyConfigurableKeyboard> {
+
+	@Override
+	protected MoveStrategyConfigurableKeyboard createStrategy() {
+		return new MoveStrategyConfigurableKeyboard();
+	}
+	
+	/**
+	 * Use the constructor with 1 parameter (Boolean).
+	 */
+	protected MoveStrategyConfigurableKeyboard createStrategyKeyboard(Boolean alwaysMove) {
+		return new MoveStrategyConfigurableKeyboard(alwaysMove);
+	}
+
+	/**
+	 * Use the constructor with 2 parameters (Boolean, SpeedVector).
+	 */
+	protected MoveStrategyConfigurableKeyboard createStrategyKeyboard(Boolean alwaysMove, SpeedVector speedVector) {
+		return new MoveStrategyConfigurableKeyboard(alwaysMove, speedVector);
+	}
+
+	/**
+	 * Use the constructor with every parameters.
+	 */
+	protected MoveStrategyConfigurableKeyboard createStrategyKeyboard(Boolean alwaysMove, SpeedVector speedVector, Boolean combineDirections) {
+		return new MoveStrategyConfigurableKeyboard(alwaysMove, speedVector, combineDirections);
+	}
+	
+	@Test
+	public void goingLeftWhenPressingTheCorrespondingConfiguredKey() {
+		int key = KeyEvent.VK_A;
+		strategy.addKeyDirection(key, new Point(-1, 0));
+		strategy.keyPressed(key);
+		assertLeft();
+	}
+	
+	@Test
+	public void goingRightWhenPressingTheCorrespondingConfiguredKey() {
+		int key = KeyEvent.VK_Z;
+		strategy.addKeyDirection(key, new Point(1, 0));
+		strategy.keyPressed(key);
+		assertRight();
+	}
+
+	@Test
+	public void stopWhenAlwaysMoveisOff() throws Exception {
+		strategy = createStrategyKeyboard(false);
+		int key = KeyEvent.VK_C;
+		strategy.addKeyDirection(key, new Point(-1, 0));
+		strategy.keyPressed(key);
+		strategy.keyReleased(key);
+		assertNoMovement();
+	}
+
+	@Test
+	public void dontStopWhenAlwaysMoveisOn() throws Exception {
+		strategy = createStrategyKeyboard(true);
+		int key = KeyEvent.VK_B;
+		strategy.addKeyDirection(key, new Point(0, 1));
+		strategy.keyPressed(key);
+		strategy.keyReleased(key);
+		assertDown();
+	}
+
+	@Test
+	public void defaultValues() throws Exception {
+		strategy = createStrategy();
+		assertTrue(strategy.alwaysMove);
+		assertNoMovement();
+	}
+	
+	@Test
+	public void settableSpeed() throws Exception {
+		strategy.setSpeed(3);
+		assertEquals(3, strategy.getSpeed());
+		strategy.setSpeed(1);
+		assertEquals(1, strategy.getSpeed());
+	}
+
+	@Test
+	public void initializedValues() throws Exception {
+		SpeedVector speedVector = new SpeedVector(new Point(5,5), 50);
+		strategy = createStrategyKeyboard(false, speedVector);
+
+		assertEquals(speedVector, strategy.speedVector);
+		assertEquals(false, strategy.alwaysMove);
+	}
+
+	@Test
+	public void shouldMoveRightWhenAlwaysMoveisOn() {
+		strategy = createStrategyKeyboard(true);
+		int leftKey = KeyEvent.VK_X;
+		int rightKey = KeyEvent.VK_U;
+		strategy.addKeyDirection(leftKey, new Point(-1, 0));
+		strategy.addKeyDirection(rightKey, new Point(1, 0));
+		strategy.keyPressed(leftKey);
+		strategy.keyReleased(leftKey);
+		strategy.keyPressed(leftKey);
+		strategy.keyReleased(leftKey);
+		strategy.keyPressed(rightKey);
+		strategy.keyReleased(rightKey);
+		assertRight();
+	}
+	
+	@Test
+	public void directionShouldBeLowerRightIfCombineIsOnAndLeftAndDownArePressedSimultaneously() {
+		strategy = createStrategyKeyboard(false, new SpeedVector(new Point(0, 0)), true);
+		int downKey = KeyEvent.VK_I;
+		int rightKey = KeyEvent.VK_V;
+		strategy.addKeyDirection(downKey, new Point(0, 1));
+		strategy.addKeyDirection(rightKey, new Point(1, 0));
+		strategy.keyPressed(downKey);
+		strategy.keyPressed(rightKey);
+		
+		assertDownRight();
+	}
+
+}

--- a/src/test/java/gameframework/motion/MoveStrategyKeyboardTest.java
+++ b/src/test/java/gameframework/motion/MoveStrategyKeyboardTest.java
@@ -8,8 +8,7 @@ import java.awt.event.KeyEvent;
 
 import org.junit.Test;
 
-public class MoveStrategyKeyboardTest extends
-		MoveStrategyTest<MoveStrategyKeyboard> {
+public class MoveStrategyKeyboardTest extends MoveStrategyConfigurableKeyboardTest {
 
 	@Override
 	protected MoveStrategyKeyboard createStrategy() {


### PR DESCRIPTION
-- Team 2 --

Adds a new class "MoveStrategyConfigurableKeyboard" which : 
- Adds the possibilty to define any key to any direction
- Fix a bug with directions pressed simultaneously : For example, when left and right were pressed, releasing one key stopped the "MovableObject". The other key (still pressed) wasn't took into account. Now every keys are "saved" to avoid that bug.
- Is less game-dependant (for example, a game like tetris would only need left and right, not 4 or 8 directions)
- Less redundant code (you don't have a big switch with every keys, and 8 directions is done without adding code)
- Adds the possibility to define two keys for the same direction (for example, to give the player the choice between arrow keys or ZQSD)

MoveStrategyKeyboard and MoveStrategyKeyboard8Dir have been rewrote to extends this new class, so they are now a lot lighter.
